### PR TITLE
本部アプリの手動設定判定と位置表示を改善

### DIFF
--- a/lib/components/battery_and_acc.dart
+++ b/lib/components/battery_and_acc.dart
@@ -6,16 +6,18 @@ class BatteryAndAcc extends StatelessWidget {
     super.key,
     required this.batteryLevel,
     required this.acc,
+    this.statusText,
   });
 
   final int batteryLevel;
   final double acc;
+  final String? statusText;
 
   @override
   Widget build(BuildContext context) {
-    if (acc == 0.0) {
-      return const Text(
-        '手動設定',
+    if (statusText != null) {
+      return Text(
+        statusText!,
         style: TextStyle(fontSize: 12, color: Colors.grey),
       );
     }

--- a/lib/models/position.dart
+++ b/lib/models/position.dart
@@ -1,13 +1,23 @@
+import 'package:bsam_admin/models/position_source.dart';
+
 class Position {
   double? lat;
   double? lng;
   double? acc;
+  PositionSource? positionSource;
 
-  Position({this.lat, this.lng, this.acc});
+  Position({this.lat, this.lng, this.acc, this.positionSource});
 
   Position.fromJson(Map<String, dynamic> json) {
     lat = json['latitude'].toDouble();
     lng = json['longitude'].toDouble();
     acc = json['accuracy'].toDouble();
+    positionSource = PositionSource.fromJsonValue(json['position_source']);
+
+    if (positionSource == null && acc == 0.0) {
+      positionSource = PositionSource.manual;
+    }
   }
+
+  bool get isManual => positionSource == PositionSource.manual;
 }

--- a/lib/models/position_source.dart
+++ b/lib/models/position_source.dart
@@ -1,0 +1,22 @@
+enum PositionSource {
+  gps('gps'),
+  manual('manual');
+
+  const PositionSource(this.value);
+
+  final String value;
+
+  static PositionSource? fromJsonValue(Object? rawValue) {
+    if (rawValue is! String) {
+      return null;
+    }
+
+    for (final source in PositionSource.values) {
+      if (source.value == rawValue) {
+        return source;
+      }
+    }
+
+    return null;
+  }
+}

--- a/lib/pages/manage/athletes_area.dart
+++ b/lib/pages/manage/athletes_area.dart
@@ -98,6 +98,7 @@ class AthleteItem extends StatelessWidget {
               BatteryAndAcc(
                 batteryLevel: athlete.batteryLevel!,
                 acc: athlete.location!.acc!,
+                statusText: _athleteStatusText(athlete),
               ),
               Container(
                 margin: const EdgeInsets.only(top: 5),
@@ -146,6 +147,15 @@ class AthleteItem extends StatelessWidget {
       ),
     );
   }
+}
+
+String? _athleteStatusText(Athlete athlete) {
+  final location = athlete.location;
+  if (location == null || location.acc == null || location.acc! <= 0.0) {
+    return '位置未取得';
+  }
+
+  return null;
 }
 
 class AthleteInfo extends StatelessWidget {

--- a/lib/pages/manage/marks_area.dart
+++ b/lib/pages/manage/marks_area.dart
@@ -81,6 +81,7 @@ class MarkItem extends StatelessWidget {
                 child: BatteryAndAcc(
                   batteryLevel: mark.batteryLevel!,
                   acc: mark.position!.acc!,
+                  statusText: mark.position!.isManual ? '手動設定' : null,
                 ),
               ),
               Visibility(

--- a/lib/pages/mark/page.dart
+++ b/lib/pages/mark/page.dart
@@ -20,6 +20,7 @@ import 'package:bsam_admin/pages/mark/app_bar.dart';
 import 'package:bsam_admin/pages/mark/debug_area.dart';
 import 'package:bsam_admin/pages/mark/map_area.dart';
 import 'package:bsam_admin/pages/mark/sending_area.dart';
+import 'package:bsam_admin/models/position_source.dart';
 import 'package:bsam_admin/utils/websocket_url_validator.dart';
 import 'package:bsam_admin/utils/reconnection_strategy.dart';
 
@@ -360,6 +361,8 @@ class _Mark extends ConsumerState<Mark> {
         'latitude': _lat,
         'longitude': _lng,
         'accuracy': _accuracy,
+        'position_source':
+            _manual ? PositionSource.manual.value : PositionSource.gps.value,
       });
 
       if (_disposed || !mounted) return;

--- a/test/models/position_test.dart
+++ b/test/models/position_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bsam_admin/models/position.dart';
+import 'package:bsam_admin/models/position_source.dart';
+
+void main() {
+  test('prefers explicit manual position source', () {
+    final position = Position.fromJson({
+      'latitude': 34.0,
+      'longitude': 136.0,
+      'accuracy': 3.0,
+      'position_source': 'manual',
+    });
+
+    expect(position.positionSource, PositionSource.manual);
+    expect(position.isManual, isTrue);
+  });
+
+  test('falls back to legacy manual accuracy for marks', () {
+    final position = Position.fromJson({
+      'latitude': 34.0,
+      'longitude': 136.0,
+      'accuracy': 0.0,
+    });
+
+    expect(position.positionSource, PositionSource.manual);
+    expect(position.isManual, isTrue);
+  });
+
+  test('keeps gps source when provided', () {
+    final position = Position.fromJson({
+      'latitude': 34.0,
+      'longitude': 136.0,
+      'accuracy': 0.0,
+      'position_source': 'gps',
+    });
+
+    expect(position.positionSource, PositionSource.gps);
+    expect(position.isManual, isFalse);
+  });
+}

--- a/test/widgets/battery_and_acc_test.dart
+++ b/test/widgets/battery_and_acc_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bsam_admin/components/battery_and_acc.dart';
+
+void main() {
+  testWidgets('renders explicit status text when provided', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: BatteryAndAcc(batteryLevel: 80, acc: 0.0, statusText: '手動設定'),
+        ),
+      ),
+    );
+
+    expect(find.text('手動設定'), findsOneWidget);
+    expect(find.text('バッテリー: '), findsNothing);
+  });
+
+  testWidgets('renders battery and accuracy when no status text exists', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: BatteryAndAcc(batteryLevel: 80, acc: 2.5)),
+      ),
+    );
+
+    expect(find.text('バッテリー: '), findsOneWidget);
+    expect(find.text('2.50m'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 概要
本部アプリで manual 判定を `accuracy == 0` から分離し、
mark 送信時に `position_source` を付与するよう修正しました。
あわせて、選手とブイで位置ステータスの表示を適切に出し分けます。

## 変更内容
- mark 送信時に `position_source: gps/manual` を追加
- mark model に `position_source` の解釈を追加
- `position_source` がない場合のみ legacy fallback として `accuracy == 0` を manual 扱い
- ブイは manual 時に `手動設定` を表示
- 選手は精度 0 / 未初期化時に `位置未取得` を表示
- model / widget テストを追加

## 背景
これまで `accuracy == 0` を manual 判定に流用していたため、
実際には手動設定ではないケースでも `手動設定` と見えてしまう余地がありました。
manual 判定と位置品質を分離し、表示の意味を明確にします。

## 確認
- `flutter test test/models/position_test.dart test/widgets/battery_and_acc_test.dart`